### PR TITLE
Clean QR generation helpers

### DIFF
--- a/pdf_library_processor.py
+++ b/pdf_library_processor.py
@@ -116,7 +116,6 @@ def generate_single_qr_global(args):
         qr_config = config.get('qr', {})
         
         # Try with progressively shorter text if QR version exceeds 40
-        original_text = chunk_text
         for max_chars in [len(chunk_text), 2800, 2400, 2000, 1600, 1200]:
             try:
                 if max_chars < len(chunk_text):
@@ -186,8 +185,8 @@ def monkey_patch_parallel_qr_generation(encoder, n_workers: int):
                     # Temporarily suppress stderr only for worker warnings, keep tqdm visible
                     with open(os.devnull, 'w') as devnull:
                         sys.stderr = devnull
-                        results = list(tqdm(executor.map(generate_single_qr_global, chunk_tasks), 
-                                           total=len(chunk_tasks), desc="Generating QR frames", file=sys.stdout))
+                        _ = list(tqdm(executor.map(generate_single_qr_global, chunk_tasks),
+                                      total=len(chunk_tasks), desc="Generating QR frames", file=sys.stdout))
                 finally:
                     sys.stderr = original_stderr
             else:

--- a/pdf_processor.py
+++ b/pdf_processor.py
@@ -70,7 +70,6 @@ def generate_single_qr_global(args):
         qr_config = config.get('qr', {}) if hasattr(config, 'get') else {}
         
         # Try with progressively shorter text if QR version exceeds 40
-        original_text = chunk_text
         for max_chars in [len(chunk_text), 2800, 2400, 2000, 1600, 1200]:
             try:
                 if max_chars < len(chunk_text):
@@ -564,8 +563,8 @@ class ModularPDFProcessor:
                         # Temporarily suppress stderr only for worker warnings, keep tqdm visible
                         with open(os.devnull, 'w') as devnull:
                             sys.stderr = devnull
-                            results = list(tqdm(executor.map(generate_single_qr_global, chunk_tasks), 
-                                               total=len(chunk_tasks), desc="Generating QR frames", file=sys.stdout))
+                            _ = list(tqdm(executor.map(generate_single_qr_global, chunk_tasks),
+                                          total=len(chunk_tasks), desc="Generating QR frames", file=sys.stdout))
                     finally:
                         sys.stderr = original_stderr
                 else:


### PR DESCRIPTION
## Summary
- remove unused `original_text` variable in `generate_single_qr_global`
- discard unused worker results when showing tqdm progress

## Testing
- `python3 pdf_processor.py --test-modules` *(fails: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6850930eb3e883308e39c03ba887acb0