### PR TITLE
Remove termios reference

### DIFF
--- a/pdf_chat.py
+++ b/pdf_chat.py
@@ -27,17 +27,9 @@ import time
 import json
 import requests
 from pathlib import Path
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, List
 
 # Import memvid only when needed to avoid dependency issues
-
-# Cross-platform keyboard input
-try:
-    import termios
-    import tty
-    HAS_TERMIOS = True
-except ImportError:
-    HAS_TERMIOS = False
 
 
 class OllamaLLM:


### PR DESCRIPTION
## Summary
- clean up imports in `pdf_chat.py`
- drop old `termios` detection block

## Testing
- `python3 pdf_processor.py --test-modules` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6850955448e48330af40985258219a44