### PR TITLE
Add initial unit tests

### DIFF
--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -1,0 +1,39 @@
+import requests
+from modules.embedding_service import EmbeddingService
+
+
+class DummyResponse:
+    def __init__(self, data, status=200):
+        self._data = data
+        self.status_code = status
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._data
+
+
+def test_embed_updates_stats(monkeypatch):
+    def mock_post(url, json=None, timeout=None):
+        return DummyResponse({"embedding": [0.1] * 768})
+    monkeypatch.setattr(requests, "post", mock_post)
+    service = EmbeddingService(batch_size=2, show_progress=False)
+    embeddings = service.embed(["a", "b", "c"])
+    assert len(embeddings) == 3
+    stats = service.get_statistics()
+    assert stats["total_requests"] == 3
+    assert stats["successful_requests"] == 3
+    assert stats["failed_requests"] == 0
+
+
+def test_health_check(monkeypatch):
+    def mock_get(url, timeout=None):
+        return DummyResponse({"models": [{"name": "nomic-embed-text"}]})
+    def mock_post(url, json=None, timeout=None):
+        return DummyResponse({"embedding": [0.0] * 768})
+    monkeypatch.setattr(requests, "get", mock_get)
+    monkeypatch.setattr(requests, "post", mock_post)
+    service = EmbeddingService(show_progress=False)
+    health = service.health_check()
+    assert health["service_available"] is True
+    assert health["model_loaded"] is True
+    assert health["embedding_test"] is True

--- a/tests/test_metadata_extractor.py
+++ b/tests/test_metadata_extractor.py
@@ -1,0 +1,31 @@
+import requests
+from modules.metadata_extractor import MetadataExtractor
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._data
+
+
+def test_extract_metadata_success(monkeypatch):
+    def mock_post(url, json, timeout):
+        return DummyResponse({"response": '{"title":"My Title","authors":"A","publishers":"P","year":"2020","doi":"123"}'})
+    monkeypatch.setattr(requests, "post", mock_post)
+    extractor = MetadataExtractor()
+    meta = extractor.extract_metadata_with_ollama("sample", "sample.pdf", max_retries=0)
+    assert meta["title"] == "My Title"
+
+
+def test_extract_metadata_fallback(monkeypatch):
+    def mock_post(url, json, timeout):
+        return DummyResponse({"response": 'not json'})
+    monkeypatch.setattr(requests, "post", mock_post)
+    extractor = MetadataExtractor()
+    meta = extractor.extract_metadata_with_ollama("sample", "Title -- Author -- 2021 -- Pub.pdf", max_retries=0)
+    assert meta["publishers"] == "Pub"
+    assert meta["year"] == "2021"
+

--- a/tests/test_pdf_chat.py
+++ b/tests/test_pdf_chat.py
@@ -1,0 +1,41 @@
+import sys
+import json
+import types
+from pathlib import Path
+from pdf_chat import MultiLibraryRetriever, PDFLibraryChat
+
+
+class DummyRetriever:
+    def __init__(self, video_file, index_file):
+        self.video_file = video_file
+        self.index_file = index_file
+    def search(self, query, top_k=5):
+        return ["A", "B"]
+
+
+def test_multi_library_search_and_citations(monkeypatch, tmp_path):
+    # create two libraries
+    libs = []
+    for i, text in enumerate(["A", "B"], 1):
+        lib_dir = tmp_path / str(i)
+        lib_dir.mkdir()
+        index_path = lib_dir / "library_index.json"
+        data = {"metadata": [{"text": text, "enhanced_metadata": {"title": f"T{i}", "page_reference": str(i)}}]}
+        index_path.write_text(json.dumps(data))
+        video_path = lib_dir / "library.mp4"
+        video_path.write_text("vid")
+        libs.append({"library_id": str(i), "name": f"Library {i}", "video_file": str(video_path), "index_file": str(index_path), "chunks": 1, "files": 1})
+
+    dummy_mod = types.SimpleNamespace(MemvidRetriever=DummyRetriever)
+    monkeypatch.setitem(sys.modules, "memvid", dummy_mod)
+
+    retriever = MultiLibraryRetriever(libs)
+    results = retriever.search("query", top_k=2)
+    assert len(results) == 2
+    assert results[0]["library_id"] == "1"
+
+    chat_stub = PDFLibraryChat.__new__(PDFLibraryChat)
+    chat_stub.chunk_citation_map = {"A": "[T1, page 1 - Library 1]", "B": "[T2, page 2 - Library 2]"}
+    cited = PDFLibraryChat._add_citations_to_context(chat_stub, ["A", "B"])
+    assert cited[0].endswith("Library 1]")
+    assert cited[1].endswith("Library 2]")

--- a/tests/test_pdf_processor_cli.py
+++ b/tests/test_pdf_processor_cli.py
@@ -1,0 +1,8 @@
+import subprocess
+import sys
+
+
+def test_cli_help():
+    result = subprocess.run([sys.executable, "pdf_processor.py", "--help"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()

--- a/tests/test_qr_generator.py
+++ b/tests/test_qr_generator.py
@@ -1,0 +1,23 @@
+import sys
+import types
+from pathlib import Path
+from modules.qr_generator import QRGenerator
+
+
+class DummyEncoder:
+    def add_text(self, text):
+        pass
+    def _build_qr_frame(self, path, index):
+        Path(path).write_text("frame")
+
+
+def test_generate_qr_frames_sequential(monkeypatch, tmp_path):
+    dummy_mod = types.SimpleNamespace(MemvidEncoder=DummyEncoder)
+    monkeypatch.setitem(sys.modules, "memvid", dummy_mod)
+
+    chunks = [{"text": "one"}, {"text": "two"}]
+    generator = QRGenerator(n_workers=1, show_progress=False)
+    frames_dir, stats = generator.generate_qr_frames_sequential(chunks, tmp_path)
+    assert stats["total_frames"] == 2
+    validation = generator.validate_frames(frames_dir)
+    assert validation["valid"] is True

--- a/tests/test_text_chunker.py
+++ b/tests/test_text_chunker.py
@@ -1,0 +1,20 @@
+import sys, types, tiktoken
+import pytest
+from modules.text_chunker import TextChunker
+
+
+def test_create_enhanced_chunks_basic(monkeypatch):
+    dummy = types.SimpleNamespace(encode=lambda x, **k: [ord(c) for c in x], decode=lambda l: "".join(chr(i) for i in l))
+    monkeypatch.setattr(tiktoken, "encoding_for_model", lambda name: dummy)
+    monkeypatch.setattr(tiktoken, "get_encoding", lambda name: dummy)
+    page_texts = {
+        1: "This is page one. " * 20,
+        2: "Second page text. " * 20,
+    }
+    chunker = TextChunker(chunk_size=50, overlap_percentage=0.0)
+    chunks = chunker.create_enhanced_chunks(page_texts)
+    assert len(chunks) > 0
+    first = chunks[0]
+    assert first.start_page == 1
+    stats = chunker.get_chunk_stats(chunks)
+    assert stats["total_chunks"] == len(chunks)

--- a/tests/test_video_assembler.py
+++ b/tests/test_video_assembler.py
@@ -1,0 +1,37 @@
+import sys
+import types
+from pathlib import Path
+from modules.video_assembler import VideoAssembler
+
+
+class DummyEncoder:
+    def __init__(self):
+        self.text_data = []
+    def add_text(self, text):
+        self.text_data.append({"text": text, "metadata": {}})
+    def build_video(self, path, fps=30, quality="medium", compression=True):
+        Path(path).write_bytes(b"video")
+    def get_index(self):
+        return self.text_data
+
+
+def test_assemble_video(monkeypatch, tmp_path):
+    dummy_mod = types.SimpleNamespace(MemvidEncoder=DummyEncoder)
+    monkeypatch.setitem(sys.modules, "memvid", dummy_mod)
+
+    chunks = [
+        {"text": "a", "metadata": {"file_name": "file.pdf", "token_count": 5, "num_pages": 1}},
+        {"text": "b", "metadata": {"file_name": "file.pdf", "token_count": 4, "num_pages": 1}},
+    ]
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    video_path = tmp_path / "out.mp4"
+    index_path = tmp_path / "index.json"
+
+    assembler = VideoAssembler()
+    result = assembler.assemble_video(frames_dir, chunks, video_path, index_path)
+    assert result["success"] is True
+    assert video_path.exists()
+    assert index_path.exists()
+    validation = assembler.validate_index_output(index_path)
+    assert validation["valid"] is True


### PR DESCRIPTION
## Summary
- add unit tests for TextChunker, MetadataExtractor and EmbeddingService
- add unit tests for QRGenerator and VideoAssembler
- provide minimal CLI and chat tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685122f2f9b483309d660ace5edee6ac